### PR TITLE
Tensor triangles must be of type int64. 

### DIFF
--- a/geometry_processing.py
+++ b/geometry_processing.py
@@ -28,11 +28,13 @@ def save_vtk(
     Args:
         fname (string): filename.
         xyz (Tensor): (N,3) point cloud or vertices.
-        triangles (integer Tensor, optional): (T,3) mesh connectivity. Defaults to None.
+        triangles (integer 64-bit Tensor, optional): (T,3) mesh connectivity. Defaults to None.
         values (Tensor, optional): (N,D) values, supported by the vertices. Defaults to None.
         vectors (Tensor, optional): (N,3) vectors, supported by the vertices. Defaults to None.
         triangle_values (Tensor, optional): (T,D) values, supported by the triangles. Defaults to None.
     """
+
+    assert triangles.dtype == torch.int64, "Triangles should be of type torch.int64."
 
     # Encode the points/vertices as a VTK structure:
     if triangles is None:  # Point cloud


### PR DESCRIPTION
Written a test script for a cube with a triangular mesh form. The triangles were passed into the save_vtk function as torch.int16 and torch.int32 and produced the same result:

```
Traceback (most recent call last):
  File "custom_geometry_value_placement.py", line 31, in <module>
    values = values)
  File "/home/tsoni/workspace/athena/drug_discovery/dMaSIF/geometry_processing.py", line 43, in save_vtk
    structure = PolyData(points=numpy(xyz), polygons=numpy(triangles))
  File "/home/tsoni/workspace/athena/venvs/drug_discovery/lib/python3.7/site-packages/pyvtk/PolyData.py", line 47, in __init__
    raise ValueError('%s must be (seq of seq|seq) integers less than %s'%(k,sz))
ValueError: polygons must be (seq of seq|seq) integers less than 8
```

Added an assertion error for the case that the user inserts a tensor of type 64 for the triangles.